### PR TITLE
修改删除知识库操作及删除附件操作的接口为DeleteMapping

### DIFF
--- a/ruoyi-modules/ruoyi-chat/src/main/java/org/ruoyi/chat/controller/knowledge/KnowledgeController.java
+++ b/ruoyi-modules/ruoyi-chat/src/main/java/org/ruoyi/chat/controller/knowledge/KnowledgeController.java
@@ -73,7 +73,7 @@ public class KnowledgeController extends BaseController {
   /**
    * 删除知识库
    */
-  @PostMapping("/remove/{id}")
+  @DeleteMapping("/remove/{id}")
   public R<String> remove(@PathVariable String id) {
     knowledgeInfoService.removeKnowledge(id);
     return R.ok("删除知识库成功!");
@@ -131,7 +131,7 @@ public class KnowledgeController extends BaseController {
   /**
    * 删除知识库附件
    */
-  @PostMapping("attach/remove/{kid}")
+  @DeleteMapping("attach/remove/{kid}")
   public R<Void> removeAttach(@NotEmpty(message = "主键不能为空")
   @PathVariable String kid) {
     attachService.removeKnowledgeAttach(kid);


### PR DESCRIPTION
问题详见前端pr：[优化 知识库删除和附件删除按钮的体验](https://github.com/ageerle/ruoyi-admin/pull/19)