### PR TITLE
feat(chat): 修复仅非管理员设置根据用户 ID查询聊天记录

### DIFF
--- a/ruoyi-modules-api/ruoyi-chat-api/src/main/java/org/ruoyi/service/impl/ChatMessageServiceImpl.java
+++ b/ruoyi-modules-api/ruoyi-chat-api/src/main/java/org/ruoyi/service/impl/ChatMessageServiceImpl.java
@@ -48,7 +48,10 @@ public class ChatMessageServiceImpl implements IChatMessageService {
         if(!LoginHelper.isLogin()){
             return TableDataInfo.build();
         }
-        bo.setUserId(LoginHelper.getUserId());
+        // 只有非管理员才自动设置为自己的 ID
+        if (!LoginHelper.isSuperAdmin()) {
+            bo.setUserId(LoginHelper.getUserId());
+        }
         LambdaQueryWrapper<ChatMessage> lqw = buildQueryWrapper(bo);
         Page<ChatMessageVo> result = baseMapper.selectVoPage(pageQuery.build(), lqw);
         return TableDataInfo.build(result);


### PR DESCRIPTION
- 在 ChatMessageServiceImpl 类中，仅当用户不是超级管理员时，才自动设置消息的用户 ID，确保了超级管理员可以查看对话聊天