### PR TITLE
修复token不扣费和扣费异常的问题

### DIFF
--- a/ruoyi-common/ruoyi-common-chat/src/main/java/org/ruoyi/common/chat/request/ChatRequest.java
+++ b/ruoyi-common/ruoyi-common-chat/src/main/java/org/ruoyi/common/chat/request/ChatRequest.java
@@ -61,4 +61,10 @@ public class ChatRequest {
      */
     private String role;
 
+
+    /**
+     * 对话id(每个聊天窗口都不一样)
+     */
+    private Long uuid;
+
 }

--- a/ruoyi-modules/ruoyi-chat/src/main/java/org/ruoyi/chat/service/chat/impl/SseServiceImpl.java
+++ b/ruoyi-modules/ruoyi-chat/src/main/java/org/ruoyi/chat/service/chat/impl/SseServiceImpl.java
@@ -81,6 +81,26 @@ public class SseServiceImpl implements ISseService {
             chatRequest.setRole(Message.Role.USER.getName());
 
             if(LoginHelper.isLogin()){
+
+				// 设置用户id
+                chatRequest.setUserId(LoginHelper.getUserId());
+
+
+                //待优化的地方 （这里请前端提交send的时候传递uuid进来或者sessionId）
+                //待优化的地方 （这里请前端提交send的时候传递uuid进来或者sessionId）
+                //待优化的地方 （这里请前端提交send的时候传递uuid进来或者sessionId）
+                {
+                    // 设置会话id
+                    if (chatRequest.getUuid() == null){
+                        //暂时随机生成会话id
+                        chatRequest.setSessionId(System.currentTimeMillis());
+                    }else{
+                        //这里或许需要修改一下，这里应该用uuid 或者 前端传递 sessionId
+                        chatRequest.setSessionId(chatRequest.getUuid());
+                    }
+                }
+
+
                 // 保存消息记录 并扣除费用
                 chatCostService.deductToken(chatRequest);
                 chatRequest.setUserId(chatCostService.getUserId());


### PR DESCRIPTION
1.本次提交的token数+未付费token数 判断大于100token的时候就进行扣费，当然这里还可以改成更多，我觉得100合适。 2.不需要进行扣费的地方屏蔽了相关代码。
3.SessionId传递异常 建议前端传递uuid，也就是每次会话的id。