### PR TITLE
解决问答实现类中重新查询模型逻辑可能导致自动选择的模型被重置问题

### DIFF
--- a/ruoyi-modules/ruoyi-chat/src/main/java/org/ruoyi/chat/service/chat/impl/ImageServiceImpl.java
+++ b/ruoyi-modules/ruoyi-chat/src/main/java/org/ruoyi/chat/service/chat/impl/ImageServiceImpl.java
@@ -118,7 +118,7 @@ public class ImageServiceImpl implements IChatService {
     @Override
     public SseEmitter chat(ChatRequest chatRequest, SseEmitter emitter) {
         // 从数据库获取 image 类型的模型配置
-        ChatModelVo chatModelVo = chatModelService.selectModelByCategory(ChatModeType.IMAGE.getCode());
+        ChatModelVo chatModelVo = chatModelService.selectModelByName(chatRequest.getModel());
         if (chatModelVo == null) {
             log.error("未找到 image 类型的模型配置");
             emitter.completeWithError(new IllegalStateException("未找到 image 类型的模型配置"));


### PR DESCRIPTION
feat: 上层已经确定模型的选择，这里只需要根据名字获取模型直接使用就好；