### PR TITLE
fix(Knowledge): 知识库删除失败

### DIFF
--- a/ruoyi-modules-api/ruoyi-knowledge-api/src/main/java/org/ruoyi/mapper/KnowledgeInfoMapper.java
+++ b/ruoyi-modules-api/ruoyi-knowledge-api/src/main/java/org/ruoyi/mapper/KnowledgeInfoMapper.java
@@ -2,6 +2,7 @@ package org.ruoyi.mapper;
 
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.ruoyi.core.mapper.BaseMapperPlus;
 import org.ruoyi.domain.KnowledgeInfo;
 import org.ruoyi.domain.vo.KnowledgeInfoVo;
@@ -15,4 +16,10 @@ import org.ruoyi.domain.vo.KnowledgeInfoVo;
 @Mapper
 public interface KnowledgeInfoMapper extends BaseMapperPlus<KnowledgeInfo, KnowledgeInfoVo> {
 
+    /**
+     * 根据kid查询知识库
+     * @param kid 知识库id
+     * @return KnowledgeInfo
+     */
+    KnowledgeInfo selectByKid(@Param("kid") String kid);
 }

--- a/ruoyi-modules-api/ruoyi-knowledge-api/src/main/java/org/ruoyi/service/IKnowledgeInfoService.java
+++ b/ruoyi-modules-api/ruoyi-knowledge-api/src/main/java/org/ruoyi/service/IKnowledgeInfoService.java
@@ -61,7 +61,7 @@ public interface IKnowledgeInfoService {
     /**
      * 删除知识库
      */
-    void removeKnowledge(String id);
+    void removeKnowledge(String kid);
 
     /**
      * 上传附件

--- a/ruoyi-modules-api/ruoyi-knowledge-api/src/main/resources/mapper/KnowledgeInfoMapper.xml
+++ b/ruoyi-modules-api/ruoyi-knowledge-api/src/main/resources/mapper/KnowledgeInfoMapper.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.ruoyi.mapper.KnowledgeInfoMapper">
+    <select id="selectByKid" resultType="org.ruoyi.domain.KnowledgeInfo">
+        SELECT * FROM knowledge_info WHERE kid = #{kid}
+    </select>
+</mapper>

--- a/ruoyi-modules/ruoyi-chat/src/main/java/org/ruoyi/chat/controller/knowledge/KnowledgeController.java
+++ b/ruoyi-modules/ruoyi-chat/src/main/java/org/ruoyi/chat/controller/knowledge/KnowledgeController.java
@@ -100,9 +100,9 @@ public class KnowledgeController extends BaseController {
     /**
      * 删除知识库
      */
-    @PostMapping("/remove/{id}")
-    public R<String> remove(@PathVariable String id) {
-        knowledgeInfoService.removeKnowledge(id);
+    @PostMapping("/remove/{kid}")
+    public R<String> remove(@PathVariable String kid) {
+        knowledgeInfoService.removeKnowledge(kid);
         return R.ok("删除知识库成功!");
     }
 

--- a/ruoyi-modules/ruoyi-chat/src/main/java/org/ruoyi/chat/service/knowledge/KnowledgeInfoServiceImpl.java
+++ b/ruoyi-modules/ruoyi-chat/src/main/java/org/ruoyi/chat/service/knowledge/KnowledgeInfoServiceImpl.java
@@ -227,11 +227,12 @@ public class KnowledgeInfoServiceImpl implements IKnowledgeInfoService {
 
     @Override
     @Transactional(rollbackFor = Exception.class)
-    public void removeKnowledge(String id) {
+    public void removeKnowledge(String kid) {
         Map<String, Object> map = new HashMap<>();
-        KnowledgeInfo knowledgeInfo = baseMapper.selectById(id);
+        KnowledgeInfo knowledgeInfo = baseMapper.selectByKid(kid);
+
         check(knowledgeInfo);
-        map.put("kid", knowledgeInfo.getId());
+        map.put("kid", knowledgeInfo.getKid());
         // 删除向量数据
         vectorStoreService.removeById(String.valueOf(knowledgeInfo.getId()), knowledgeInfo.getVectorModelName());
         // 删除附件和知识片段


### PR DESCRIPTION
接口：删除知识库
原因：前端传的是kid参数，而后端使用getById方法查询，查询不到对应知识库，导致删除失败
方案：使用kid查询