### PR TITLE
fix(pom): 在 ruoyi-extend 中添加缺失的 ruoyi-ai-copilot 模块

### DIFF
--- a/ruoyi-extend/pom.xml
+++ b/ruoyi-extend/pom.xml
@@ -15,6 +15,7 @@
 
     <modules>
         <module>ruoyi-mcp-server</module>
+        <module>ruoyi-ai-copilot</module>
     </modules>
 
 </project>


### PR DESCRIPTION
fix(pom): 在 ruoyi-extend 中添加缺失的 ruoyi-ai-copilot 模块 