### PR TITLE
fix(chat):解决依赖冲突导致方法不存在的问题

### DIFF
--- a/ruoyi-modules-api/ruoyi-knowledge-api/pom.xml
+++ b/ruoyi-modules-api/ruoyi-knowledge-api/pom.xml
@@ -107,11 +107,6 @@
             <artifactId>commons-compress</artifactId>
         </dependency>
 
-      <dependency>
-        <groupId>com.alibaba</groupId>
-        <artifactId>dashscope-sdk-java</artifactId>
-        <version>2.19.0</version>
-      </dependency>
         <dependency>
             <groupId>org.ruoyi</groupId>
             <artifactId>ruoyi-chat-api</artifactId>


### PR DESCRIPTION
fix: 去除 ruoyi-knowledge-api 中的 dashscope-sdk-java 依赖以解决依赖冲突导致的 enableThinking 方法不存在的问题

修复运行时抛出的 NoSuchMethodError: 'enableThinking(Boolean)'

该问题导致 AI 聊天接口（/chat/send）调用通义千问模型时失败。

<img width="1734" height="648" alt="image" src="https://github.com/user-attachments/assets/3de0fe92-5689-4766-a419-c6529cbf320b" />
