### PR TITLE
docs: distinguish open-source demo address

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@
 *An out-of-the-box full-stack AI platform supporting multi-agent collaboration, Supervisor mode orchestration, and multiple decision models, with advanced RAG technology and visual workflow orchestration capabilities*
 
 **[中文](README_ZH.md)** | **[📖 Documentation](https://doc.ruoyiai.chat/)** |
-**[🚀 Live Demo](https://web.ruoyiai.chat/)** | **[🐛 Report Issues](https://github.com/ageerle/ruoyi-ai/issues)** | **[💡 Feature Requests](https://github.com/ageerle/ruoyi-ai/issues)**
+**[🚀 Open-source Live Demo](https://web.ruoyiai.chat/)** | **[🐛 Report Issues](https://github.com/ageerle/ruoyi-ai/issues)** | **[💡 Feature Requests](https://github.com/ageerle/ruoyi-ai/issues)**
+
+> This is the RuoYi AI open-source demo environment, kept separate from the commercial edition's service entry and runtime environment.
 
 </div>
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -18,7 +18,9 @@
 *开箱即用的全栈AI平台，支持多智能体协同、Supervisor模式编排、多种决策模式、RAG技术和流程编排能力*
 
 **[English](README.md)** | **[📖 使用文档](https://doc.ruoyiai.chat/)** |
-**[🚀 在线体验](https://web.ruoyiai.chat/)** | **[🐛 问题反馈](https://github.com/ageerle/ruoyi-ai/issues)** | **[💡 功能建议](https://github.com/ageerle/ruoyi-ai/issues)**
+**[🚀 开源版在线体验](https://web.ruoyiai.chat/)** | **[🐛 问题反馈](https://github.com/ageerle/ruoyi-ai/issues)** | **[💡 功能建议](https://github.com/ageerle/ruoyi-ai/issues)**
+
+> 该地址为 RuoYi AI 开源版体验环境，与商业版服务入口和运行环境相互独立。
 
 </div>
 


### PR DESCRIPTION
## What changed

- Label `https://web.ruoyiai.chat/` as the RuoYi AI open-source live demo in both README files.
- Clarify that the open-source demo environment is separate from the commercial edition's service entry and runtime environment.

## Validation

- `git diff --check`
- Confirmed the working tree contains only the two intended README changes.
- No application code or deployment configuration was changed.
