### PR TITLE
fix: 修复 mainExecutor 线程池在高核CPU服务器上会空指针导致应用无法启动

### DIFF
--- a/ruoyi-modules/ruoyi-aiflow/src/main/java/org/ruoyi/workflow/config/BeanConfig.java
+++ b/ruoyi-modules/ruoyi-aiflow/src/main/java/org/ruoyi/workflow/config/BeanConfig.java
@@ -54,8 +54,10 @@ public class BeanConfig {
         int processorsNum = Runtime.getRuntime().availableProcessors();
         log.info("mainExecutor,processorsNum:{}", processorsNum);
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(processorsNum * 2);
-        executor.setMaxPoolSize(100);
+        // 核心线程数不得超过最大线程数
+        int maxPoolSize = 100;
+        executor.setCorePoolSize(Math.min(processorsNum * 2, maxPoolSize));
+        executor.setMaxPoolSize(maxPoolSize);
         return executor;
     }
 


### PR DESCRIPTION
### 问题描述
在高核（CPU 核心数 > 50）服务器上，`mainExecutor` 线程池配置会导致启动失败。

### 根因分析
`corePoolSize = processorsNum * 2` 可能超过 `maxPoolSize = 100`，`ThreadPoolTaskExecutor` 底层调用 `ThreadPoolExecutor` 构造时抛出无 message 的 `IllegalArgumentException`，被 Spring 包装为 `BeanCreationException: null`。

### 修复方案
使用 `Math.min(processorsNum * 2, maxPoolSize)` 保证核心线程数不超过最大线程数，避免非法参数异常。