### PR TITLE
feat: add LiteLLM as chat and embedding provider

### DIFF
--- a/ruoyi-modules/ruoyi-chat/src/main/java/org/ruoyi/enums/ChatModeType.java
+++ b/ruoyi-modules/ruoyi-chat/src/main/java/org/ruoyi/enums/ChatModeType.java
@@ -20,6 +20,7 @@ public enum ChatModeType {
     MINIMAX("minimax", "MiniMax"),
     DIFY("dify", "Dify"),
     COZE("coze", "Coze"),
+    LITE_LLM("litellm", "LiteLLM"),
     XIAOMI("xiaomi", "小米MiMo");
     private final String code;
     private final String description;

--- a/ruoyi-modules/ruoyi-chat/src/main/java/org/ruoyi/service/chat/impl/provider/LiteLLMServiceImpl.java
+++ b/ruoyi-modules/ruoyi-chat/src/main/java/org/ruoyi/service/chat/impl/provider/LiteLLMServiceImpl.java
@@ -1,0 +1,52 @@
+package org.ruoyi.service.chat.impl.provider;
+
+
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.ruoyi.common.chat.domain.dto.request.ChatRequest;
+import org.ruoyi.common.chat.domain.vo.chat.ChatModelVo;
+import org.ruoyi.enums.ChatModeType;
+import org.ruoyi.observability.MyChatModelListener;
+import org.ruoyi.service.chat.AbstractChatService;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+
+
+/**
+ * LiteLLM chat service.
+ * <p>
+ * LiteLLM proxy exposes an OpenAI-compatible endpoint, so it reuses the OpenAI
+ * protocol builder. Point apiHost at the LiteLLM proxy (e.g. http://localhost:4000/v1)
+ * to reach 100+ providers (OpenAI, Anthropic, Gemini, Bedrock, Vertex AI, Azure ...)
+ * through a single provider entry with unified auth, routing and observability.
+ *
+ * @author ageerle@163.com
+ * @date 2025/12/13
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class LiteLLMServiceImpl implements AbstractChatService {
+
+    @Override
+    public StreamingChatModel buildStreamingChatModel(ChatModelVo chatModelVo, ChatRequest chatRequest) {
+        return OpenAiStreamingChatModel.builder()
+                .baseUrl(chatModelVo.getApiHost())
+                .apiKey(chatModelVo.getApiKey())
+                .modelName(chatModelVo.getModelName())
+                .timeout(Duration.ofMinutes(30))
+                .listeners(List.of(new MyChatModelListener()))
+                .returnThinking(chatRequest.getEnableThinking())
+                .build();
+    }
+
+    @Override
+    public String getProviderName() {
+        return ChatModeType.LITE_LLM.getCode();
+    }
+
+}

--- a/ruoyi-modules/ruoyi-chat/src/main/java/org/ruoyi/service/embed/impl/LiteLLMEmbeddingProvider.java
+++ b/ruoyi-modules/ruoyi-chat/src/main/java/org/ruoyi/service/embed/impl/LiteLLMEmbeddingProvider.java
@@ -1,0 +1,18 @@
+package org.ruoyi.service.embed.impl;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * LiteLLM embedding model (OpenAI-compatible).
+ * <p>
+ * LiteLLM proxy speaks the OpenAI embeddings protocol, so this reuses the OpenAI
+ * embedding builder. Point apiHost at the LiteLLM proxy to generate embeddings
+ * through any LiteLLM-supported provider (OpenAI, Cohere, Voyage, Bedrock ...).
+ *
+ * @author ageerle@163.com
+ */
+@Component("litellm")
+@org.springframework.context.annotation.Scope("prototype")
+public class LiteLLMEmbeddingProvider extends OpenAiEmbeddingProvider {
+
+}

--- a/ruoyi-modules/ruoyi-chat/src/test/java/org/ruoyi/service/chat/impl/provider/LiteLLMServiceImplTest.java
+++ b/ruoyi-modules/ruoyi-chat/src/test/java/org/ruoyi/service/chat/impl/provider/LiteLLMServiceImplTest.java
@@ -1,0 +1,68 @@
+package org.ruoyi.service.chat.impl.provider;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.ruoyi.common.chat.domain.dto.request.ChatRequest;
+import org.ruoyi.common.chat.domain.vo.chat.ChatModelVo;
+import org.ruoyi.enums.ChatModeType;
+import org.ruoyi.service.chat.AbstractChatService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Unit tests for LiteLLMServiceImpl
+ */
+@Tag("dev")
+class LiteLLMServiceImplTest {
+
+    private LiteLLMServiceImpl liteLLMService;
+
+    @BeforeEach
+    void setUp() {
+        liteLLMService = new LiteLLMServiceImpl();
+    }
+
+    @Test
+    void getProviderName_returnsLiteLLMCode() {
+        assertEquals("litellm", liteLLMService.getProviderName());
+        assertEquals(ChatModeType.LITE_LLM.getCode(), liteLLMService.getProviderName());
+    }
+
+    @Test
+    void buildStreamingChatModel_usesOpenAiCompatibleProtocol() {
+        ChatRequest request = new ChatRequest();
+        request.setEnableThinking(false);
+
+        StreamingChatModel model = liteLLMService.buildStreamingChatModel(
+            modelVo("http://localhost:4000/v1", "gpt-4o-mini"), request);
+
+        assertInstanceOf(OpenAiStreamingChatModel.class, model);
+    }
+
+    @Test
+    void buildChatModel_usesOpenAiCompatibleProtocol() {
+        ChatModel model = liteLLMService.buildChatModel(
+            modelVo("http://localhost:4000/v1", "gpt-4o-mini"));
+
+        assertInstanceOf(OpenAiChatModel.class, model);
+    }
+
+    @Test
+    void implementsAbstractChatService() {
+        assertInstanceOf(AbstractChatService.class, liteLLMService);
+    }
+
+    private static ChatModelVo modelVo(String apiHost, String modelName) {
+        ChatModelVo modelVo = new ChatModelVo();
+        modelVo.setApiHost(apiHost);
+        modelVo.setApiKey("test-api-key");
+        modelVo.setModelName(modelName);
+        return modelVo;
+    }
+}

--- a/ruoyi-modules/ruoyi-chat/src/test/java/org/ruoyi/service/embed/impl/LiteLLMEmbeddingProviderTest.java
+++ b/ruoyi-modules/ruoyi-chat/src/test/java/org/ruoyi/service/embed/impl/LiteLLMEmbeddingProviderTest.java
@@ -1,0 +1,60 @@
+package org.ruoyi.service.embed.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.ruoyi.common.chat.domain.vo.chat.ChatModelVo;
+import org.ruoyi.enums.ModalityType;
+import org.ruoyi.service.embed.BaseEmbedModelService;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for LiteLLMEmbeddingProvider
+ */
+@Tag("dev")
+class LiteLLMEmbeddingProviderTest {
+
+    private LiteLLMEmbeddingProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        provider = new LiteLLMEmbeddingProvider();
+    }
+
+    @Test
+    void implementsBaseEmbedModelService() {
+        assertInstanceOf(BaseEmbedModelService.class, provider);
+    }
+
+    @Test
+    void extendsOpenAiEmbeddingProvider() {
+        assertInstanceOf(OpenAiEmbeddingProvider.class, provider);
+    }
+
+    @Test
+    void getSupportedModalities_returnsText() {
+        Set<ModalityType> modalities = provider.getSupportedModalities();
+        assertNotNull(modalities);
+        assertTrue(modalities.contains(ModalityType.TEXT));
+        assertEquals(1, modalities.size());
+    }
+
+    @Test
+    void configure_setsModelConfig() {
+        ChatModelVo config = new ChatModelVo();
+        config.setApiHost("http://localhost:4000/v1");
+        config.setApiKey("test-api-key");
+        config.setModelName("text-embedding-3-small");
+        config.setModelDimension(1536);
+
+        provider.configure(config);
+        // configure sets internal state; verify no exception thrown
+        assertNotNull(provider);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds **LiteLLM as a first class chat and embedding provider**, mirroring the existing OpenAI compatible providers (`OpenAIServiceImpl` / `OpenAiEmbeddingProvider`).
- A LiteLLM proxy exposes an OpenAI compatible endpoint, so one provider entry gives users access to 100+ LLM providers (OpenAI, Anthropic, Gemini, AWS Bedrock, Google Vertex AI, Azure, Groq, etc.) through a single unified interface with centralized auth, routing, cost tracking, and observability.
- Additive only: no existing provider is touched and no new dependency is added (reuses the langchain4j OpenAI client already on the classpath).


## Changes
- `enums/ChatModeType.java`: adds `LITE_LLM("litellm", "LiteLLM")` (auto surfaces in the provider dropdown).
- `service/chat/impl/provider/LiteLLMServiceImpl.java`: new chat provider mirroring `OpenAIServiceImpl`, auto registered by `getProviderName()`.
- `service/embed/impl/LiteLLMEmbeddingProvider.java`: new embedding provider extending `OpenAiEmbeddingProvider`, mirroring `MinimaxEmbeddingProvider`.
- Unit tests for both (`@Tag("dev")`).


## Tests

**1. Unit tests** (`mvn -Pdev -pl ruoyi-modules/ruoyi-chat test -Dtest='LiteLLMServiceImplTest,LiteLLMEmbeddingProviderTest'`):
```
Running org.ruoyi.service.embed.impl.LiteLLMEmbeddingProviderTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
Running org.ruoyi.service.chat.impl.provider.LiteLLMServiceImplTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

**2. Live end to end** through the real provider (`LiteLLMServiceImpl.buildChatModel(...).chat(...)`) against a running LiteLLM proxy, on two different upstream providers routed by the same provider entry:
```
[E2E] model=gpt-4.1-mini      reply=RUOYI_LITELLM_OK
[E2E] model=gemini-2.5-flash  reply=RUOYI_LITELLM_OK
```
This proves the full chain: `LiteLLMServiceImpl` to the langchain4j OpenAI client to the LiteLLM proxy `/v1` to the upstream provider, with the response parsed back through the repo's `ChatModel`.

**3. Build:** `mvn -pl ruoyi-modules/ruoyi-chat -am install -DskipTests` gives BUILD SUCCESS (JDK 21).

## Risk / Compatibility
- Additive; existing providers untouched.
- No new dependency (reuses the langchain4j OpenAI client).
- The new provider is inert unless a user creates a model with provider `litellm`.

## Example usage

Normal usage is config driven: the service auto registers under `getProviderName()` = `"litellm"`, so `ChatServiceFactory` selects it whenever a model's provider is LiteLLM.

1. Run a LiteLLM proxy (e.g. `litellm --config config.yaml --port 4000`).
2. In model management, add a chat model with provider **LiteLLM**, `apiHost = http://localhost:4000/v1`, your proxy key, and any model name the proxy exposes (e.g. `gpt-4o-mini`, `claude-3-5-sonnet`, `gemini-2.5-flash`).
3. Chat as usual; requests route through the proxy to the chosen backend. Same pattern for embeddings.

Under the hood the factory hands the model config to this service, which builds a langchain4j model against the proxy. Model, host, and key all come from the `ChatModelVo`, nothing hardcoded:

```java
ChatModelVo vo = new ChatModelVo();
vo.setApiHost("http://localhost:4000/v1");
vo.setApiKey(apiKey);
vo.setModelName("gpt-4o-mini");          // any model the proxy exposes

AbstractChatService svc = chatServiceFactory.getService("litellm");  // -> LiteLLMServiceImpl
ChatModel model = svc.buildChatModel(vo);
String reply = model.chat("What is 2+2?");   // -> "4"
```
